### PR TITLE
Do not block keys when directed to a widget in an output cell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_hide_code",
-  "version": "4.0.0",
+  "version": "4.1.1",
   "description": "A button in JupyterLab to run the code cells and then to hide the code cells.",
   "keywords": [
     "jupyter",

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,13 @@ export class ButtonExtension
       if (!hidden) {
         return;
       }
+      // Let keys through when the event originates inside a cell's output
+      // area — ipywidgets and similar interactive outputs live there and
+      // may need keys for their own handlers.
+      const target = event.target as HTMLElement | null;
+      if (target && target.closest('.jp-OutputArea')) {
+        return;
+      }
       // Cell type: m, y, r, 1-6
       // Add/remove/reorder: a, b, d (dd), x, v, z, Shift+M
       const blockedKeys = [


### PR DESCRIPTION
Disabling keyboard shortcuts had a bad unintended consequence of also blocking those keys for interactive widgets in the output. This PR filters the filter, so that it does not apply to output cells that contain editable widgets. 